### PR TITLE
New option to ignore ssl verification of Jenkins server

### DIFF
--- a/jenkins_cli/__init__.py
+++ b/jenkins_cli/__init__.py
@@ -17,6 +17,7 @@ def main():
     parser.add_argument('--host', metavar='jenkins-url', help='Jenkins Host', default=None)
     parser.add_argument('--username', metavar='username', help='Jenkins Username', default=None)
     parser.add_argument('--password', metavar='password', help='Jenkins Password', default=None)
+    parser.add_argument('--ignore-ssl', action='store_true', help='Disable SSL verification')
     parser.add_argument('--version', '-v', action='version', version='jenkins-cli %s' % version)
 
     subparsers = parser.add_subparsers(title='Available commands', dest='jenkins_command')

--- a/jenkins_cli/cli.py
+++ b/jenkins_cli/cli.py
@@ -34,7 +34,6 @@ STATUSES_COLOR = {'blue': {'symbol': 'S',
 
 # Default constants to parse booleans from .jenkins-cli
 TRUE = ['yes', 'Yes', 'YES', 'True', 'true', 'TRUE', '1']
-FALSE = ['no', 'No', 'NO', 'False', 'false', 'FALSE', '0']
 
 
 ENDCOLLOR = '\033[0m'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,5 +311,6 @@ class TestCliCommands(unittest.TestCase):
         self.patched_print.assert_has_calls([mock.call("FDN Job1 estimated time left %s" % timedelta(seconds=TS))],
                                             [mock.call("FDN Job5 estimated time left %s" % timedelta(seconds=TS))])
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For folks like me, that still has to deal with self-signed certificates :)

This fixes the issue #26.