### PR TITLE
Fix console output && add a --interval CLI option

### DIFF
--- a/jenkins_cli/__init__.py
+++ b/jenkins_cli/__init__.py
@@ -1,65 +1,15 @@
 from __future__ import print_function
 
-import argparse
 from jenkins import JenkinsException
 
-from jenkins_cli.cli import JenkinsCli, CliException, get_jobs_legend, check_nonnegative
-from jenkins_cli.version import version
+from jenkins_cli.cli import JenkinsCli, CliException
+from jenkins_cli.cli_arguments import load_parser
 
 
 def main():
-    parser = argparse.ArgumentParser(prog='jenkins',
-                                     description='Host, username and password may be specified either by the command line arguments '
-                                                 'or in the configuration file (.jenkins-cli). Command line arguments have the highest priority, '
-                                                 'after that the .jenkins-cli file from current folder is used. If there is no'
-                                                 '.jenkins-cli file in the current folder, settings will be read from .jenkins-cli located in the home'
-                                                 'folder')
-    parser.add_argument('--host', metavar='jenkins-url', help='Jenkins Host', default=None)
-    parser.add_argument('--username', metavar='username', help='Jenkins Username', default=None)
-    parser.add_argument('--password', metavar='password', help='Jenkins Password', default=None)
-    parser.add_argument('--version', '-v', action='version', version='jenkins-cli %s' % version)
-
-    subparsers = parser.add_subparsers(title='Available commands', dest='jenkins_command')
-
-    jobs_parser = subparsers.add_parser('jobs',
-                                        help='Show all jobs and their statuses',
-                                        formatter_class=argparse.RawTextHelpFormatter,
-                                        description="Status description:\n\n" + "\n".join(get_jobs_legend()))
-    jobs_parser.add_argument('-a', help='show only active jobs', default=False, action='store_true')
-    jobs_parser.add_argument('-p', help='show only jobs in build progress', default=False, action='store_true')
-
-    subparsers.add_parser('queue', help='Show builds queue')
-
-    subparsers.add_parser('building', help='Build executor status')
-
-    builds_parser = subparsers.add_parser('builds', help='Show builds for the job')
-    builds_parser.add_argument('job_name', help='Job name of the builds')
-
-    start_parser = subparsers.add_parser('start', help='Start job')
-    start_parser.add_argument('job_name', help='Job to start', nargs='*')
-
-    start_parser = subparsers.add_parser('info', help='Job info')
-    start_parser.add_argument('job_name', help='Job to get info for')
-
-    set_branch = subparsers.add_parser('setbranch', help='Set VCS branch (Mercurial or Git)')
-    set_branch.add_argument('job_name', help='Job to set branch for')
-    set_branch.add_argument('branch_name', help='Name of the VCS branch')
-
-    stop_parser = subparsers.add_parser('stop', help='Stop job')
-    stop_parser.add_argument('job_name', help='Job to stop')
-
-    console_parser = subparsers.add_parser('console', help='Show console for the build')
-    console_parser.add_argument('job_name', help='Job to show console for')
-    console_parser.add_argument('-b', '--build', help='job build number to show console for (if omitted, last build number is used)', default='')
-    console_parser.add_argument('-n', help='show first n lines only(if n is negative, show last n lines)', type=int)
-    console_parser.add_argument('-i', help='interactive console', default=False, action='store_true')
-    console_parser.add_argument('-t', '--interval', help='refresh interval in seconds (in case of interactive console -i)', default=3, type=check_nonnegative)
-
-    console_parser = subparsers.add_parser('changes', help="Show build's changes")
-    console_parser.add_argument('job_name', help='Job to show changes for')
-    console_parser.add_argument('-b', '--build', help='job build number to show changes for (if omitted, last build number is used)', default='')
-
+    parser = load_parser()
     args = parser.parse_args()
+
     try:
         if args.jenkins_command is None:
             parser.print_help()

--- a/jenkins_cli/__init__.py
+++ b/jenkins_cli/__init__.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import argparse
 from jenkins import JenkinsException
 
-from jenkins_cli.cli import JenkinsCli, CliException, get_jobs_legend
+from jenkins_cli.cli import JenkinsCli, CliException, get_jobs_legend, check_nonnegative
 from jenkins_cli.version import version
 
 
@@ -53,6 +53,7 @@ def main():
     console_parser.add_argument('-b', '--build', help='job build number to show console for (if omitted, last build number is used)', default='')
     console_parser.add_argument('-n', help='show first n lines only(if n is negative, show last n lines)', type=int)
     console_parser.add_argument('-i', help='interactive console', default=False, action='store_true')
+    console_parser.add_argument('-t', '--interval', help='refresh interval in seconds (in case of interactive console -i)', default=3, type=check_nonnegative)
 
     console_parser = subparsers.add_parser('changes', help="Show build's changes")
     console_parser.add_argument('job_name', help='Job to show changes for')

--- a/jenkins_cli/cli.py
+++ b/jenkins_cli/cli.py
@@ -3,6 +3,7 @@ import os
 import sys
 import datetime
 from time import time, sleep
+import argparse
 import jenkins
 import socket
 from xml.etree import ElementTree
@@ -69,6 +70,22 @@ def get_jobs_legend():
 
 def xml_to_string(root):
     return ElementTree.tostring(root, encoding=('unicode' if sys.version_info[0] == 3 else None))
+
+
+def check_nonnegative(value):
+    """
+    Checks if (possibly string) value is non-negative integer and returns it.
+
+    Raise:
+        ArgumentTypeError: if value is not a non-negative integer
+    """
+    try:
+        ivalue = int(value)
+        if ivalue < 0:
+            raise ValueError()
+    except:
+        raise argparse.ArgumentTypeError("Value must be a non-negative integer: %s" % value)
+    return ivalue
 
 
 class CliException(Exception):
@@ -308,7 +325,7 @@ class JenkinsCli(object):
                     if new_line_num > last_line_num:
                         print("\n".join(console_out[last_line_num:]))
                         last_line_num = new_line_num
-                    sleep(3)
+                    sleep(args.interval)
                     build_info = self.jenkins.get_build_info(job_name, build_number)
 
     def building(self, args):

--- a/jenkins_cli/cli.py
+++ b/jenkins_cli/cli.py
@@ -294,7 +294,7 @@ class JenkinsCli(object):
             print("Cannot show console output. %(job_name)s has no builds" % {'job_name': job_name})
         else:
             console_out = self.jenkins.get_build_console_output(job_name, build_number)
-            console_out = console_out.split('\n')
+            console_out = console_out.splitlines()
             last_line_num = len(console_out)
             if args.n:
                 console_out = console_out[args.n:] if args.n < 0 else console_out[:args.n]
@@ -303,7 +303,7 @@ class JenkinsCli(object):
                 build_info = self.jenkins.get_build_info(job_name, build_number)
                 while build_info['building']:
                     console_out = self.jenkins.get_build_console_output(job_name, build_number)
-                    console_out = console_out.split('\n')
+                    console_out = console_out.splitlines()
                     new_line_num = len(console_out)
                     if new_line_num > last_line_num:
                         print("\n".join(console_out[last_line_num:]))

--- a/jenkins_cli/cli.py
+++ b/jenkins_cli/cli.py
@@ -3,7 +3,6 @@ import os
 import sys
 import datetime
 from time import time, sleep
-import argparse
 import jenkins
 import socket
 from xml.etree import ElementTree
@@ -70,22 +69,6 @@ def get_jobs_legend():
 
 def xml_to_string(root):
     return ElementTree.tostring(root, encoding=('unicode' if sys.version_info[0] == 3 else None))
-
-
-def check_nonnegative(value):
-    """
-    Checks if (possibly string) value is non-negative integer and returns it.
-
-    Raise:
-        ArgumentTypeError: if value is not a non-negative integer
-    """
-    try:
-        ivalue = int(value)
-        if ivalue < 0:
-            raise ValueError()
-    except:
-        raise argparse.ArgumentTypeError("Value must be a non-negative integer: %s" % value)
-    return ivalue
 
 
 class CliException(Exception):

--- a/jenkins_cli/cli_arguments.py
+++ b/jenkins_cli/cli_arguments.py
@@ -1,0 +1,80 @@
+import argparse
+
+from jenkins_cli.cli import get_jobs_legend
+from jenkins_cli.version import version
+
+
+def load_parser():
+    """
+    Create a parser and load it with CLI arguments
+
+    Returns: ArgumentParser instance
+    """
+    parser = argparse.ArgumentParser(prog='jenkins',
+                                     description='Host, username and password may be specified either by the command line arguments '
+                                                 'or in the configuration file (.jenkins-cli). Command line arguments have the highest priority, '
+                                                 'after that the .jenkins-cli file from current folder is used. If there is no'
+                                                 '.jenkins-cli file in the current folder, settings will be read from .jenkins-cli located in the home'
+                                                 'folder')
+    parser.add_argument('--host', metavar='jenkins-url', help='Jenkins Host', default=None)
+    parser.add_argument('--username', metavar='username', help='Jenkins Username', default=None)
+    parser.add_argument('--password', metavar='password', help='Jenkins Password', default=None)
+    parser.add_argument('--version', '-v', action='version', version='jenkins-cli %s' % version)
+
+    subparsers = parser.add_subparsers(title='Available commands', dest='jenkins_command')
+
+    jobs_parser = subparsers.add_parser('jobs',
+                                        help='Show all jobs and their statuses',
+                                        formatter_class=argparse.RawTextHelpFormatter,
+                                        description="Status description:\n\n" + "\n".join(get_jobs_legend()))
+    jobs_parser.add_argument('-a', help='show only active jobs', default=False, action='store_true')
+    jobs_parser.add_argument('-p', help='show only jobs in build progress', default=False, action='store_true')
+
+    subparsers.add_parser('queue', help='Show builds queue')
+
+    subparsers.add_parser('building', help='Build executor status')
+
+    builds_parser = subparsers.add_parser('builds', help='Show builds for the job')
+    builds_parser.add_argument('job_name', help='Job name of the builds')
+
+    start_parser = subparsers.add_parser('start', help='Start job')
+    start_parser.add_argument('job_name', help='Job to start', nargs='*')
+
+    start_parser = subparsers.add_parser('info', help='Job info')
+    start_parser.add_argument('job_name', help='Job to get info for')
+
+    set_branch = subparsers.add_parser('setbranch', help='Set VCS branch (Mercurial or Git)')
+    set_branch.add_argument('job_name', help='Job to set branch for')
+    set_branch.add_argument('branch_name', help='Name of the VCS branch')
+
+    stop_parser = subparsers.add_parser('stop', help='Stop job')
+    stop_parser.add_argument('job_name', help='Job to stop')
+
+    console_parser = subparsers.add_parser('console', help='Show console for the build')
+    console_parser.add_argument('job_name', help='Job to show console for')
+    console_parser.add_argument('-b', '--build', help='job build number to show console for (if omitted, last build number is used)', default='')
+    console_parser.add_argument('-n', help='show first n lines only(if n is negative, show last n lines)', type=int)
+    console_parser.add_argument('-i', help='interactive console', default=False, action='store_true')
+    console_parser.add_argument('-t', '--interval', help='refresh interval in seconds (in case of interactive console -i)', default=3, type=check_nonnegative)
+
+    console_parser = subparsers.add_parser('changes', help="Show build's changes")
+    console_parser.add_argument('job_name', help='Job to show changes for')
+    console_parser.add_argument('-b', '--build', help='job build number to show changes for (if omitted, last build number is used)', default='')
+
+    return parser
+
+
+def check_nonnegative(value):
+    """
+    Checks if (possibly string) value is non-negative integer and returns it.
+
+    Raise:
+        ArgumentTypeError: if value is not a non-negative integer
+    """
+    try:
+        ivalue = int(value)
+        if ivalue < 0:
+            raise ValueError()
+    except:
+        raise argparse.ArgumentTypeError("Value must be a non-negative integer: %s" % value)
+    return ivalue


### PR DESCRIPTION
Adding one bugfix and one new CLI option

1. Bugfix: newlines caused that during `jenkins console -i myjob` some lines were lost.
2. Feature: Adding `-t`/`--interval` option which let's users specify the frequency of console output updates