### PR TITLE
Support multiple Jenkins instances in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ Host, username and password may be specified either by the command line argument
 
 **.jenkins-cli** example
 ```txt
+[DEFAULT]
 host=http://localhost:8082/
 username=username
 password=******
+
+[prod]
+host=https://production-jenkins.example.com/
+username=username
+password=xxxxxx
 ```
 
 # Commands overview:

--- a/jenkins_cli/cli.py
+++ b/jenkins_cli/cli.py
@@ -134,7 +134,8 @@ class JenkinsCli(object):
         try:
             return dict(config.items(environment))
         except NoSectionError:
-            raise CliException('No such environment: %s' % environment)
+            raise CliException('%s section not found in .jenkins-cli config'
+                               ' file' % environment)
 
     def run_command(self, args):
         command = args.jenkins_command

--- a/jenkins_cli/cli.py
+++ b/jenkins_cli/cli.py
@@ -126,7 +126,8 @@ class JenkinsCli(object):
         # read the config file
         config = ConfigParser()
         try:
-            config.readfp(open(filename, 'r'))
+            with open(filename, 'r') as f:
+                config.readfp(f)
         except Exception as e:
             raise CliException('Error reading %s: %s' % (filename, e))
 

--- a/jenkins_cli/cli_arguments.py
+++ b/jenkins_cli/cli_arguments.py
@@ -20,6 +20,8 @@ def load_parser():
     parser.add_argument('--username', metavar='username', help='Jenkins Username', default=None)
     parser.add_argument('--password', metavar='password', help='Jenkins Password', default=None)
     parser.add_argument('--version', '-v', action='version', version='jenkins-cli %s' % version)
+    parser.add_argument('-e', '--environment',
+                        help='Which config section to use')
 
     subparsers = parser.add_subparsers(title='Available commands', dest='jenkins_command')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,18 @@ class TestCliFileUsing(fake_filesystem_unittest.TestCase):
                           "password=myPassword\n"
                           "other_setting=some_value")
 
+    MULTIENV_FILE_CONTENT = ("[DEFAULT]\n"
+                             "host =https://jenkins.host.com\n"
+                             "username=   username\n"
+                             "some default settings = value = value\n"
+                             "\n"
+                             "[alternative]\n"
+                             "host=http://jenkins.localhosthost.ua\n"
+                             "username=Denys\n"
+                             "password=myPassword\n"
+                             "other_setting=some_value"
+                             )
+
     def setUp(self):
         self.setUpPyfakefs()
 
@@ -115,6 +127,30 @@ class TestCliFileUsing(fake_filesystem_unittest.TestCase):
                           "username": "Denys",
                           "password": "myPassword",
                           "other_setting": "some_value"
+                          })
+
+    def test_read_settings_from_file_alt_environment(self):
+        # make sure we are in the fake fs
+        current_folder = os.getcwd()
+        local_folder_filename = os.path.join(current_folder, JenkinsCli.SETTINGS_FILE_NAME)
+        self.assertFalse(os.path.exists(local_folder_filename))
+
+        # create the fake config file
+        self.fs.CreateFile(local_folder_filename,
+                           contents=self.MULTIENV_FILE_CONTENT)
+        self.assertTrue(os.path.exists(local_folder_filename))
+
+        # read the config from the file
+        settings_dict = JenkinsCli.read_settings_from_file(environment='alternative')
+
+        # test and that the alternative environment is used, with the missing
+        #   values being provided from the DEFAULT environmtne
+        self.assertEqual(settings_dict,
+                         {"host": 'http://jenkins.localhosthost.ua',
+                          "username": "Denys",
+                          "password": "myPassword",
+                          "other_setting": "some_value",
+                          'some default settings': 'value = value'
                           })
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,11 +75,13 @@ class TestCliAuth(unittest.TestCase):
 
 
 class TestCliFileUsing(fake_filesystem_unittest.TestCase):
-    HOME_FILE_CONTENT = ("host =https://jenkins.host.com\n"
+    HOME_FILE_CONTENT = ("[DEFAULT]\n"
+                         "host =https://jenkins.host.com\n"
                          "username=   username\n"
                          "some weird settings = value = value")
 
-    LOCAL_FILE_CONTENT = ("host=http://jenkins.localhosthost.ua\n"
+    LOCAL_FILE_CONTENT = ("[DEFAULT]\n"
+                          "host=http://jenkins.localhosthost.ua\n"
                           "username=Denys\n"
                           "password=myPassword\n"
                           "other_setting=some_value")
@@ -97,7 +99,7 @@ class TestCliFileUsing(fake_filesystem_unittest.TestCase):
         self.fs.CreateFile(home_folder_filename,
                            contents=self.HOME_FILE_CONTENT)
         self.assertTrue(os.path.exists(home_folder_filename))
-        settings_dict = JenkinsCli.read_settings_from_file()
+        settings_dict = JenkinsCli.read_settings_from_file(environment=None)
         self.assertEqual(settings_dict,
                          {"host": 'https://jenkins.host.com',
                           "username": "username",
@@ -107,7 +109,7 @@ class TestCliFileUsing(fake_filesystem_unittest.TestCase):
         self.fs.CreateFile(local_folder_filename,
                            contents=self.LOCAL_FILE_CONTENT)
         self.assertTrue(os.path.exists(local_folder_filename))
-        settings_dict = JenkinsCli.read_settings_from_file()
+        settings_dict = JenkinsCli.read_settings_from_file(environment=None)
         self.assertEqual(settings_dict,
                          {"host": 'http://jenkins.localhosthost.ua',
                           "username": "Denys",
@@ -119,7 +121,7 @@ class TestCliFileUsing(fake_filesystem_unittest.TestCase):
 class TestCliCommands(unittest.TestCase):
 
     def setUp(self):
-        self.args = Namespace(host='http://jenkins.host.com', username=None, password=None)
+        self.args = Namespace(host='http://jenkins.host.com', username=None, password=None, environment=None)
         self.print_patcher = mock.patch('jenkins_cli.cli.print')
         self.patched_print = self.print_patcher.start()
 


### PR DESCRIPTION
This commit adds sections to the .jenkins-cli config file. The section
which should be used is specified with the -e or --environment. If no
environment is specified, the "DEFAULT" section is used.

Fixes #36 
