### PR TITLE
Do not install bash completion as non-root

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,12 @@ data_files = []
 completion_dirs = ['/usr/share/bash-completion/completions',
                    '/usr/local/opt/bash-completion/etc/bash_completion.d']
 
-for d in completion_dirs:
-    if os.path.isdir(d):
-        data_files.append((d, ['contrib/bash-completion/jenkins']))
+if os.geteuid() == 0:
+    for d in completion_dirs:
+        if os.path.isdir(d):
+            data_files.append((d, ['contrib/bash-completion/jenkins']))
+else:
+    print("Non-root user detected. Bash completion won't be installed.")
 
 setup(
     name='jenkins-cli',


### PR DESCRIPTION
This commit will detect if user runs setup.py as root and it will
install the bash completion files only in that case.

Note that the warning message about bash completion files not being
installed is printed only if the installation is run with -v or
--verbose flag.

Fixes #37