### PR TITLE
Add bash completion for job names

### DIFF
--- a/contrib/bash-completion/jenkins
+++ b/contrib/bash-completion/jenkins
@@ -26,13 +26,18 @@ _jenkins()
     case $prev in
       jobs)
         opts="-h --help -a -p"
-        COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
-        return 0
           ;;
-      queue|building|builds|start|info|configxml|setbranch|stop|console|changes)
+      builds|start|info|configxml|setbranch|stop|console|changes)
         opts="-h --help"
-        COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
-        return 0
+
+        # if the cached-jobs file exists suggest also job names
+        CACHE_DIR=${XDG_CACHE_HOME:-~/.cache}"/python-jenkins-cli"
+        if [ -r $CACHE_DIR/job_cache ]; then
+          opts="$opts $(cat $CACHE_DIR/job_cache)"
+        fi
+          ;;
+      queue|building)
+        opts="-h --help"
           ;;
     esac
 

--- a/jenkins_cli/cli.py
+++ b/jenkins_cli/cli.py
@@ -6,6 +6,7 @@ from time import time, sleep
 import jenkins
 import socket
 from xml.etree import ElementTree
+from xdg.BaseDirectory import save_cache_path
 
 STATUSES_COLOR = {'blue': {'symbol': 'S',
                            'color': '\033[94m',
@@ -77,6 +78,7 @@ class CliException(Exception):
 
 class JenkinsCli(object):
     SETTINGS_FILE_NAME = '.jenkins-cli'
+    JOB_CACHE_FILE_NAME = 'job_cache'
 
     QUEUE_EMPTY_TEXT = "Building queue is empty"
 
@@ -129,9 +131,17 @@ class JenkinsCli(object):
 
     def jobs(self, args):
         jobs = self._get_jobs(args)
+
+        # print jobs
         for job in jobs:
             formated_status = get_formated_status(job['color'])
             print(formated_status + " " + job['name'])
+
+        # save job names to cache file
+        our_cache_dir = save_cache_path('python-jenkins-cli')
+        job_cache_file = os.path.join(our_cache_dir, self.JOB_CACHE_FILE_NAME)
+        with open(job_cache_file, 'w') as f:
+            f.write(' '.join(job['name'] for job in jobs))
 
     def _get_jobs(self, args):
         jobs = self.jenkins.get_jobs()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyfakefs==2.7.0
 mock==2.0.0
 unittest2==1.1.0
 flake8==2.5.4
+pyxdg==0.25

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ else:
     raise RuntimeError('Unable to find version string.')
 
 requires = ['python-jenkins==0.4.14',
-            'six>=1.9.0']
+            'six>=1.9.0',
+            'pyxdg>=0.25']
 
 tests_require = ['unittest2==1.1.0',
                  'mock==2.0.0',


### PR DESCRIPTION
This commit adds suggestion of job names to the bash completion script.
The list of available jobs is stored in a cache file (by default
~/.cache/python-jenkins-cli/job_cache) and is refreshed with every
`jenkins jobs` call.

Fixes #4