### PR TITLE
Add platform checks when determining if installing under root user.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,16 @@
 import os
+import sys
 import re
 from setuptools import setup, find_packages
+
+if sys.platform == 'win32':
+    import ctypes
+
+try:
+    is_root_user = os.geteuid() == 0
+except AttributeError:
+    is_root_user = ctypes.windll.shell32.IsUserAnAdmin() != 0
+
 
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.rst')) as f:
@@ -26,7 +36,7 @@ data_files = []
 completion_dirs = ['/usr/share/bash-completion/completions',
                    '/usr/local/opt/bash-completion/etc/bash_completion.d']
 
-if os.geteuid() == 0:
+if is_root_user:
     for d in completion_dirs:
         if os.path.isdir(d):
             data_files.append((d, ['contrib/bash-completion/jenkins']))

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,14 @@
+import ctypes
 import os
 import sys
 import re
 from setuptools import setup, find_packages
 
-if sys.platform == 'win32':
-    import ctypes
 
 try:
     is_root_user = os.geteuid() == 0
 except AttributeError:
-    is_root_user = ctypes.windll.shell32.IsUserAnAdmin() != 0
+    is_root_user = sys.platform == 'win32' and ctypes.windll.shell32.IsUserAnAdmin() != 0
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This is a fix for issue #57.  The `setup.py` script now assigns a Boolean flag `is_root_user` by attempting to assign the result of `os.geteuid()==0`.  If that assignment throws an exception, then we attempt to set this by doing an FFI call to the Windows Shell API.

This has been tested on Windows 7 & Arch Linux.